### PR TITLE
feat: remove deprecated U flag in read()

### DIFF
--- a/sqlpy/sqlpy.py
+++ b/sqlpy/sqlpy.py
@@ -459,6 +459,6 @@ def load_queries(filepath):
     for file in filepath:
         if not os.path.exists(file):
             raise SQLLoadException('Could not find file', file)
-        with open(file, 'rU') as queries_file:
+        with open(file, 'r') as queries_file:
             f = f + '\n\n' + queries_file.read().strip('\n')
     return parse_queires_string(f)


### PR DESCRIPTION
```
test/unit/services/test_companies.py: 34 warnings
  /usr/local/lib/python3.8/site-packages/sqlpy/sqlpy.py:462: DeprecationWarning: 'U' mode is deprecated
    with open(file, 'rU') as queries_file:
```
---


What's New In Python 3.4 (The Deprecation Warning):
This release note confirms that the DeprecationWarning was introduced in Python 3.4.

[Python 3.4 Release Notes (Check the Deprecated section)](https://docs.python.org/3/whatsnew/3.4.html)

Python 3.11 Deprecation/Removal Notes (The Final Removal):
This documentation confirms that the 'U' mode, after being deprecated for years.


TODO fix tox:
https://github.com/9fin/sqlpy/blob/master/tox.ini#L8
